### PR TITLE
Add __future__ imports for Python 3 compatibility

### DIFF
--- a/src/autorsyncbackup.py
+++ b/src/autorsyncbackup.py
@@ -1,4 +1,8 @@
 #!/usr/bin/python
+
+from __future__ import absolute_import
+from __future__ import print_function
+
 import time, threading
 from optparse import OptionParser
 from prettytable import PrettyTable

--- a/src/lib/command.py
+++ b/src/lib/command.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import subprocess, paramiko, time, socket;
 from .logger import logger
 

--- a/src/lib/director.py
+++ b/src/lib/director.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import glob, os, re, time, datetime, shutil
 from models.job import job
 from models.config import config

--- a/src/lib/director.py
+++ b/src/lib/director.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import division
 
 import glob, os, re, time, datetime, shutil
 from models.job import job

--- a/src/lib/jinjafilters.py
+++ b/src/lib/jinjafilters.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import division
 
 import datetime
 import re

--- a/src/lib/jinjafilters.py
+++ b/src/lib/jinjafilters.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import datetime
 import re
 from collections import OrderedDict

--- a/src/lib/jobthread.py
+++ b/src/lib/jobthread.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import threading, time
 from lib.logger import logger
 

--- a/src/lib/logger.py
+++ b/src/lib/logger.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
 import logging, os
 
 class logger():

--- a/src/lib/pidfile.py
+++ b/src/lib/pidfile.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import sys, os, errno
 
 class Pidfile():

--- a/src/lib/rsync.py
+++ b/src/lib/rsync.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from models.config import config
 from lib.logger import logger
 import subprocess, paramiko, time, socket;

--- a/src/lib/statuscli.py
+++ b/src/lib/statuscli.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
 from prettytable import PrettyTable
 from models.jobrunhistory import jobrunhistory
 from lib.jinjafilters import jinjafilters

--- a/src/lib/statusemail.py
+++ b/src/lib/statusemail.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import division
 
 import datetime
 from models.config import config

--- a/src/lib/statusemail.py
+++ b/src/lib/statusemail.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import datetime
 from models.config import config
 from models.jobrunhistory import jobrunhistory

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
 import yaml, socket
 
 class config():

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
 import yaml
 from .config import config
 from lib.logger import logger

--- a/src/models/jobrunhistory.py
+++ b/src/models/jobrunhistory.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import datetime
 import sqlite3
 import time


### PR DESCRIPTION
To have autorsyncbackup behave the same as Python 3 when using Python 2 certain imports from `__future__` are required as documented in [The Conservative Python 3 Porting Guide](https://portingguide.readthedocs.io/en/latest/):

 * [absolute_imports](https://portingguide.readthedocs.io/en/latest/imports.html)
 * [division](https://portingguide.readthedocs.io/en/latest/numbers.html#division)
 * [print_statement](https://portingguide.readthedocs.io/en/latest/builtins.html)

The division changes are most significant because dividing int will now result in floats instead of truncated ints. Because this is more desirable behavior, the `//` operator for truncated division is not used to keep the Python 2 results.

The changes were suggested by `pylint --py3k`.