### PR TITLE
Added integrity check to see if job history corresponds with job

### DIFF
--- a/src/autorsyncbackup.py
+++ b/src/autorsyncbackup.py
@@ -54,7 +54,6 @@ def runBackup(jobpath, dryrun):
             # Run director
             directorInstance = director()
             jobs = directorInstance.getJobArray(jobpath)
-
             # Start threads
             threads = []
             if not dryrun:

--- a/src/lib/director.py
+++ b/src/lib/director.py
@@ -38,9 +38,9 @@ class director():
                 logger().debug('command %s' % ('succeeded' if c['returncode'] == 0 else 'failed'))
             else:
                 logger().debug('Running remote command %s' % c['script'])
-                c['returncode'],  c['stdout'],  c['stderr'] =  comm.executeRemoteCommand(job,  c['script'])
+                c['returncode'],  c['stdout'],  c['stderr'] = comm.executeRemoteCommand(job,  c['script'])
                 logger().debug('command %s' % ('succeeded' if c['returncode'] == 0 else 'failed'))
-            if c['returncode'] != 0 and c['continueonerror'] == False:
+            if c['returncode'] != 0 and c['continueonerror'] is False:
                 logger().debug('command failed and continueonerror = false: exception')
                 raise CommandException('Hook %s failed to execute' % c['script'])
 
@@ -54,7 +54,7 @@ class director():
             logger().error("Required command failed (%s), skipping remainder of job" % e)
             job.backupstatus['rsync_backup_status'] = 0
             job.backupstatus['rsync_stdout'] = "No output due to failed required 'Before' command"
-            return 0;
+            return 0
         job.backupstatus['startdatetime'] = int(time.time())
         ret = rsync().executeRsync(job, latest)
         job.backupstatus['enddatetime'] = int(time.time())
@@ -63,7 +63,7 @@ class director():
             self.executeJobs(job, job.afterLocalHooks)
         except CommandException as e:
             logger().error("Required command failed (%s), skipping remainder of job" % e)
-            return 0;
+            return 0
         return ret
 
     def checkBackupEnvironment(self, job):
@@ -351,8 +351,9 @@ class director():
         job.backupstatus['backupdir'] = job.backupdir
         job.backupstatus['speedlimitkb'] = job.speedlimitkb
         job.backupstatus['type'] = self.getWorkingDirectory()
+        job.backupstatus['integrity_id'] = job.integrity_id
         self.parseRsyncOutput(job)
-        jrh = jobrunhistory(check = True)
+        jrh = jobrunhistory(check=True)
         jrh.insertJob(job.backupstatus,  job.hooks)
         jrh.closeDbHandler()
 

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -1,4 +1,4 @@
-import yaml
+import yaml, uuid
 from .config import config
 from lib.logger import logger
 
@@ -29,6 +29,7 @@ class job():
         self.include = []
         self.exclude = []
         self.backupstatus = {}
+        self.integrity_id = str(uuid.uuid1())
         self.readJob()
     
     def readJob(self):

--- a/src/models/jobrunhistory.py
+++ b/src/models/jobrunhistory.py
@@ -52,6 +52,7 @@ class jobrunhistory():
         jobrunhistoryTable = 'CREATE TABLE IF NOT EXISTS jobrunhistory \
                                 ( \
                                     id INTEGER PRIMARY KEY  AUTOINCREMENT, \
+                                    integrity_id TEXT, \
                                     hostname TEXT, \
                                     startdatetime INTEGER, \
                                     enddatetime INTEGER, \
@@ -131,6 +132,8 @@ class jobrunhistory():
             self.conn.commit()
             logger().debug("Commited job history to database")
         except Exception as e:
+            logger().debug(columns)
+            logger().debug(backupstatus.values())
             logger().error("Could not insert job details for host (%s) into the database (%s): %s" % (backupstatus['hostname'], self.dbdirectory + "/autorsyncbackup.db", e))
     
     def identifyJob(self, job, directory):

--- a/src/templates/email.j2
+++ b/src/templates/email.j2
@@ -358,7 +358,7 @@
                                     {% for jrh in jobrunhistory %}
                                     <table cellpadding="0" cellspacing="0" class="card" style="margin-top: 20px">
                                       <tr>
-                                        <td style="background-color:{%- if jrh.rsync_backup_status == 1 and jrh.sanity_check == 1 and jrh.commanderror == 'ok' %}green{% elif jrh.rsync_backup_status == 1 and jrh.sanity_check == 1 and jrh.commanderror == 'warning' %}orange{%- else %}red{%- endif %}; text-align:center; padding:10px; color:white !important;"><span style="color: #fff">{{ jrh.hostname }}</span></td>
+                                        <td style="background-color:{%- if jrh.rsync_backup_status == 1 and jrh.sanity_check == 1 and jrh.commanderror == 'ok' and jrh.integrity_confirmed %}green{% elif jrh.rsync_backup_status == 1 and jrh.sanity_check == 1 and jrh.commanderror == 'warning' %}orange{%- else %}red{%- endif %}; text-align:center; padding:10px; color:white !important;"><span style="color: #fff">{{ jrh.hostname }}</span></td>
                                       </tr>
                                       <tr>
                                         <td style="border:1px solid {% if jrh.rsync_backup_status == 1 and jrh.sanity_check == 1 and jrh.commanderror == 'ok' %}green{% elif jrh.rsync_backup_status == 1 and jrh.sanity_check == 1 and jrh.commanderror == 'warning' %}orange{% else %}red{% endif %}; padding: 20px 0 20px;">
@@ -381,6 +381,10 @@
                                                   <tr>
                                                     <td class="data-heading" width="50%">Sanity check</td>
                                                     <td class="data-value">{%- if jrh.sanity_check == 1 %}Ok{%- else %}Error, check backup folder for duplicate id's and/or check the sequence.{%- endif %}</td>
+                                                  </tr>
+                                                  <tr>
+                                                    <td class="data-heading" width="50%">Integrity</td>
+                                                    <td class="data-value">{%- if jrh.integrity_confirmed == 1 %}Ok{%- else %}The integrity of the job log (this section of this email) could not be confirmed. Something probably went wrong while trying to insert the logs into the database. This does not necessarily mean that the job has failed.{%- endif %}</td>
                                                   </tr>
                                                   <tr>
                                                     <td class="data-heading" width="50%">Missing files and directories</td>


### PR DESCRIPTION
Added an integrity_id to all the joblogs, when sending the logs via email, the integrity_id of the job in the database is compared with the integrity_id of, what should be, the same job in memory. If they are not the same, the email will show an integrity error.


Since this change modifies the database the following migration is needed:

Go into your sqlite shell:
`sqlite3 /var/spool/autorsyncbackup/autorsyncbackup.db`
Migrate:
`ALTER TABLE jobrunhistory ADD integrity_id text;`