### PR TITLE
Call closeDbHandler after insertJob & deleteHistory to close the sqlite connection.

### DIFF
--- a/src/autorsyncbackup.py
+++ b/src/autorsyncbackup.py
@@ -101,7 +101,9 @@ def runBackup(jobpath, dryrun):
                         # Add to queue
                         workQueue.put(job)
                 else:
-                    jobrunhistory().insertJob(job.backupstatus, None)
+                    jrh = jobrunhistory()
+                    jrh.insertJob(job.backupstatus, None)
+                    jrh.closeDbHandler()
             queueLock.release()
             # Wait for queue to empty
             while not workQueue.empty():
@@ -121,7 +123,9 @@ def runBackup(jobpath, dryrun):
                 for job in jobs:
                     if job.backupstatus['rsync_backup_status'] == 1:
                         directorInstance.backupRotate(job)
-                jobrunhistory().deleteHistory()
+                jrh = jobrunhistory()
+                jrh.deleteHistory()
+                jrh.closeDbHandler()
                 durationstats['housekeepingenddatetime'] = int(time.time())
 
                 # Sent status report

--- a/tests/etc/director/disabled.job
+++ b/tests/etc/director/disabled.job
@@ -1,0 +1,24 @@
+enabled: False
+hostname: disabled
+rsync_username: autorsyncbackup
+rsync_password: fee-fi-fo-fum
+rsync_share: backup
+ssh: False
+ssh_sudo: False
+ssh_username: autorsyncbackup
+ssh_privatekey: /home/autorsyncbackup/.ssh/id_rsa
+include: #formerly fileset
+  - /etc
+exclude:
+  - "*.bak"
+  - ".cache/*"
+hooks:
+  - script: uptime
+    local: true
+    runtime: before
+    continueonerror: true
+
+  - script: cat /etc/motd
+    local: false
+    runtime: after
+    continueonerror: true


### PR DESCRIPTION
After disabling a job the status email contained many integrity issues because for the jobs following the disabled one the integrity_id did not match what was recorded in the history.

This seems to caused by the `jobrunhistory().insertJob(job.backupstatus, None)` calls. The `__init__` method of the `jobrunhistory` class establishes the sqlite connection, but it is never closed and hence the changes to the sqlite database are not written to disk.

Other classes which use `jobrunhistory` take care to close the connection by calling the `closeDbHandler()` method in their `__del__` method.

The changes in this PR explicitly call the `closeDbHandler()` method after calling `insertJob()` & `deleteHistory()` to ensure that the sqlite connection is closed.

This PR contains an additional change to test the director with a disabled job which brings the test coverage back to 100%  after being reduced by the changes in #52:
```
----------- coverage: platform linux, python 3.6.9-final-0 -----------
Name                                                                         Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------------------------------------------------------
/home/travis/build/Nextpertise/autorsyncbackup/src/_version.py                   1      0      0      0   100%
/home/travis/build/Nextpertise/autorsyncbackup/src/autorsyncbackup.py          101      0     30      0   100%
/home/travis/build/Nextpertise/autorsyncbackup/src/lib/__init__.py               0      0      0      0   100%
/home/travis/build/Nextpertise/autorsyncbackup/src/lib/command.py               42      0      2      0   100%
/home/travis/build/Nextpertise/autorsyncbackup/src/lib/director.py             313      0     96      1    99%   30->28
/home/travis/build/Nextpertise/autorsyncbackup/src/lib/jinjafilters.py          91      0     40      0   100%
/home/travis/build/Nextpertise/autorsyncbackup/src/lib/jobthread.py             30      0      4      0   100%
/home/travis/build/Nextpertise/autorsyncbackup/src/lib/logger.py                50      0     18      0   100%
/home/travis/build/Nextpertise/autorsyncbackup/src/lib/pidfile.py               55      0     10      0   100%
/home/travis/build/Nextpertise/autorsyncbackup/src/lib/rsync.py                128      0     32      0   100%
/home/travis/build/Nextpertise/autorsyncbackup/src/lib/statuscli.py             34      0      4      0   100%
/home/travis/build/Nextpertise/autorsyncbackup/src/lib/statusemail.py          174      0     46      0   100%
/home/travis/build/Nextpertise/autorsyncbackup/src/models/__init__.py            0      0      0      0   100%
/home/travis/build/Nextpertise/autorsyncbackup/src/models/config.py            132      0      2      0   100%
/home/travis/build/Nextpertise/autorsyncbackup/src/models/job.py               214      0     30      0   100%
/home/travis/build/Nextpertise/autorsyncbackup/src/models/jobrunhistory.py     122      0     28      0   100%
------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                         1487      0    342      1    99%
```
https://api.travis-ci.com/v3/job/356728917/log.txt