### PR TITLE
Fixes for Debian bullseye

### DIFF
--- a/src/_version.py
+++ b/src/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.1.0"
+__version__ = "2.1.0"  # pragma: no cover

--- a/src/lib/director.py
+++ b/src/lib/director.py
@@ -135,9 +135,9 @@ class director():
                      job.hostname + "/" + directory)
         try:
             dirlist = os.listdir(directory)
-            for l in dirlist:
-                if re.match(self.regexp_backupdirectory, l):
-                    retlist.append(l)
+            for i in dirlist:
+                if re.match(self.regexp_backupdirectory, i):
+                    retlist.append(i)
         except Exception:
             logger().error(("Error while listing working directory (%s)"
                             " for host (%s)") % (directory, job.hostname))
@@ -186,9 +186,9 @@ class director():
         dirlist = self.getBackups(job)
         ret = False
         backup_id = 0
-        for l in dirlist:
-            if self.getIdfromBackupInstance(l) >= backup_id:
-                ret = backup_id = self.getIdfromBackupInstance(l)
+        for i in dirlist:
+            if self.getIdfromBackupInstance(i) >= backup_id:
+                ret = backup_id = self.getIdfromBackupInstance(i)
         return ret
 
     def backupRotate(self, job, moveCurrent=True):
@@ -225,10 +225,10 @@ class director():
 
         backupRetention = int(getattr(job, workingDirectory + "rotation"))
 
-        for l in self.getBackups(job):
-            if self.getIdfromBackupInstance(l):
-                if self.getIdfromBackupInstance(l) > (backupRetention - 1):
-                    self._unlinkExpiredBackup(job, directory + "/" + l)
+        for i in self.getBackups(job):
+            if self.getIdfromBackupInstance(i):
+                if self.getIdfromBackupInstance(i) > (backupRetention - 1):
+                    self._unlinkExpiredBackup(job, directory + "/" + i)
         return True
 
     def _unlinkExpiredBackup(self, job, backupdirectory):
@@ -355,8 +355,8 @@ class director():
         ret = True
 
         # Check for duplicate id's
-        for l in dirlist:
-            backup_id = self.getIdfromBackupInstance(l)
+        for i in dirlist:
+            backup_id = self.getIdfromBackupInstance(i)
             if backup_id in found_ids:
                 ret = False
             found_ids.append(backup_id)

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -66,7 +66,7 @@ class config():
             self.debugmessages.append("Reading main config from %s"
                                       % self.mainconfigpath)
             with open(self.mainconfigpath, 'r') as stream:
-                config = yaml.load(stream)
+                config = yaml.safe_load(stream)
         except Exception:
             exitcode = 1
             print("%s: Error while reading main config, exiting (%d)"

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -40,7 +40,7 @@ class job():
     def readJob(self):
         try:
             with open(self.filepath, 'r') as stream:
-                jobconfig = yaml.load(stream)
+                jobconfig = yaml.safe_load(stream)
         except Exception:
             logger().error("Error while reading %s, skipping job"
                            % self.filepath)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -81,10 +81,10 @@ def test_readConfig(test_config, tmp_path):
 
 
 def test_readConfig_load_exception(monkeypatch, capsys):
-    def mock_load(stream):
+    def mock_safe_load(stream):
         raise IOError('Mock load failure')
 
-    monkeypatch.setattr(yaml, 'load', mock_load)
+    monkeypatch.setattr(yaml, 'safe_load', mock_safe_load)
 
     with pytest.raises(SystemExit) as e:
         config().readConfig()
@@ -98,10 +98,10 @@ def test_readConfig_load_exception(monkeypatch, capsys):
 
 
 def test_readConfig_exceptions(monkeypatch):
-    def mock_load(stream):
+    def mock_safe_load(stream):
         return {}
 
-    monkeypatch.setattr(yaml, 'load', mock_load)
+    monkeypatch.setattr(yaml, 'safe_load', mock_safe_load)
 
     config().debugmessages = []
 


### PR DESCRIPTION
Running the tests in a Debian bullseye environment revealed some issues.

 * flake8: E741 ambiguous variable name 'l'.
   Fixed by renaming the variable to the more common `i` for iterators

 * `yaml.load()` is deprecated
   Fixed by using `safe_load()` instead

 * False positive for lack of test coverage for `_version.__version__`.
   Fixed by marking the statement as `no cover`