### PR TITLE
Fix #55 - Use markupsafe for markup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 testpaths = tests
-addopts = -v --cov=src --cov-config=setup.cfg --cov-report=term-missing
+addopts = -v
 
 [coverage:run]
 branch = True

--- a/src/lib/jinjafilters.py
+++ b/src/lib/jinjafilters.py
@@ -1,7 +1,7 @@
 import datetime
 import re
 
-from jinja2 import Markup
+from markupsafe import Markup
 
 
 class jinjafilters():


### PR DESCRIPTION
switch to markupsafe-Markup due to deprecation of Markup in jinja2.
jinja2 only did a redirect anyway.