### PR TITLE
Fixes for Debian bookworm

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 testpaths = tests
-addopts = -v
+addopts = -v --cov=src --cov-config=setup.cfg --cov-report=term-missing
 
 [coverage:run]
 branch = True

--- a/src/lib/command.py
+++ b/src/lib/command.py
@@ -18,9 +18,13 @@ class command():
         time.sleep(initial_wait)
         for x in range(retries):
             try:
+                kwargs = {}
+                if job.sshdisabledalgs:
+                    kwargs['disabled_algorithms'] = job.sshdisabledalgs
                 ssh.connect(job.hostname,
                             username=job.sshusername,
-                            key_filename=job.sshprivatekey)
+                            key_filename=job.sshprivatekey,
+                            **kwargs)
                 logger().info(("Successfully connected to host"
                                " via ssh protocol (%s)") % job.hostname)
                 return True
@@ -38,9 +42,13 @@ class command():
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:
+            kwargs = {}
+            if job.sshdisabledalgs:
+                kwargs['disabled_algorithms'] = job.sshdisabledalgs
             ssh.connect(job.hostname,
                         username=job.sshusername,
-                        key_filename=job.sshprivatekey)
+                        key_filename=job.sshprivatekey,
+                        **kwargs)
             logger().info(("Successfully connected to host"
                            " via ssh protocol (%s)") % job.hostname)
 

--- a/src/lib/director.py
+++ b/src/lib/director.py
@@ -23,7 +23,7 @@ class director():
         jobArray = []
         if jobpath is None:
             directory = config().jobconfigdirectory.rstrip('/')
-            if(os.path.exists(directory)):
+            if (os.path.exists(directory)):
                 os.chdir(directory)
                 for filename in glob.glob("*.job"):
                     j = job(directory + "/" + filename)
@@ -196,10 +196,10 @@ class director():
         self._unlinkExpiredBackups(job)
 
         # Rotate backups
-        if(self._rotateBackups(job)):
+        if (self._rotateBackups(job)):
             latest = self._moveCurrentBackup(job)
             if latest:
-                if(self._updateLatestSymlink(job, latest)):
+                if (self._updateLatestSymlink(job, latest)):
                     pass
                 else:
                     logger().error(("Error updating current symlink"
@@ -339,10 +339,10 @@ class director():
     def getWorkingDirectory(self):
         """Check in which folder we place the backup today"""
         ret = "daily"
-        if(int(datetime.datetime.today().strftime("%w")) ==
+        if (int(datetime.datetime.today().strftime("%w")) ==
            config().weeklybackup):
             ret = "weekly"
-        if(int(datetime.datetime.today().strftime("%d")) ==
+        if (int(datetime.datetime.today().strftime("%d")) ==
            config().monthlybackup):
             ret = "monthly"
         return ret
@@ -383,7 +383,7 @@ class director():
 
     def processBackupStatus(self, job):
         job.backupstatus['hostname'] = job.hostname
-        if(job.ssh):
+        if (job.ssh):
             ssh = 'True'
             job.backupstatus['username'] = job.sshusername
         else:

--- a/src/lib/logger.py
+++ b/src/lib/logger.py
@@ -65,7 +65,7 @@ class logger():
             # Create and remember instance
             logger.__instance = logger.__impl()
 
-            if(logfile):  # pragma: no cover
+            if (logfile):  # pragma: no cover
                 logdirectory = os.path.dirname(logfile)
                 if not os.path.exists(logdirectory):
                     os.makedirs(logdirectory)

--- a/src/lib/rsync.py
+++ b/src/lib/rsync.py
@@ -60,9 +60,13 @@ class rsync():
         time.sleep(initial_wait)
         for x in range(retries):
             try:
+                kwargs = {}
+                if job.sshdisabledalgs:
+                    kwargs['disabled_algorithms'] = job.sshdisabledalgs
                 ssh.connect(job.hostname,
                             username=job.sshusername,
-                            key_filename=job.sshprivatekey)
+                            key_filename=job.sshprivatekey,
+                            **kwargs)
                 logger().info(("Successfully connected to host"
                                " via ssh protocol (%s)") % job.hostname)
                 return True

--- a/src/lib/rsync.py
+++ b/src/lib/rsync.py
@@ -103,13 +103,13 @@ class rsync():
 
         # Link files to the same inodes as last backup to save disk space
         # and boost backup performance
-        if(latest):
+        if (latest):
             latest = "--link-dest=%s" % latest
         else:
             latest = ""
 
         # Generate rsync CLI command and execute it
-        if(include):
+        if (include):
             password = "export RSYNC_PASSWORD=\"%s\"" % job.rsyncpassword
             rsyncCommand = "%s %s %s %s %s" % (
                            config().rsyncpath, options, latest, include, dir)
@@ -139,13 +139,13 @@ class rsync():
 
         # Link files to the same inodes as last backup to save disk space
         # and boost backup performance
-        if(latest):
+        if (latest):
             latest = "--link-dest=%s" % latest
         else:
             latest = ""
 
         # Generate rsync CLI command and execute it
-        if(include):
+        if (include):
             command = "%s %s %s %s %s" % (
                       config().rsyncpath, options, latest, include, directory)
             logger().info("Executing rsync command (%s)" % command)

--- a/src/lib/statusemail.py
+++ b/src/lib/statusemail.py
@@ -116,7 +116,8 @@ class statusemail():
         return template.render(exc=exc)
 
     def getOverallBackupState(self, jobs):
-        """Overall backup state = 'ok' unless there is at least one failed backup.
+        """Overall backup state = 'ok' unless there is at least one failed
+           backup.
            At the same time reorder the list so errors appear first."""
         ret = "ok"
         good = []

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -45,7 +45,7 @@ class config():
             # Create and remember instance
             config.__instance = config.__impl()
 
-            if(mainconfigpath):  # pragma: no cover
+            if (mainconfigpath):  # pragma: no cover
                 self.mainconfigpath = mainconfigpath
             self.readConfig()
             self.init = False

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -17,6 +17,7 @@ class job():
         self.rsyncshare = None
         self.sshusername = None
         self.sshprivatekey = None
+        self.sshdisabledalgs = None
         self.port = None
         self.backupdir = None
         self.speedlimitkb = None
@@ -111,6 +112,13 @@ class job():
                                % self.filepath)
                 self.enabled = False
                 return False
+
+        try:
+            self.sshdisabledalgs = jobconfig['ssh_disabledalgs']
+        except Exception:
+            self.sshdisabledalgs = {}
+            logger().debug(("%s: No or invalid ssh_disabledalgs is set,"
+                            " using default") % self.filepath)
 
         try:
             self.port = jobconfig['port']

--- a/tests/etc/localhost.job
+++ b/tests/etc/localhost.job
@@ -6,6 +6,10 @@ ssh: False
 ssh_sudo: False
 ssh_username: autorsyncbackup
 ssh_privatekey: /home/autorsyncbackup/.ssh/id_rsa
+ssh_disabledalgs:
+  pubkeys:
+    - rsa-sha2-512
+    - rsa-sha2-256
 port: 10873
 backupdir: /tmp
 speedlimitkb: 10000

--- a/tests/etc/ssh-disabledalgs.job
+++ b/tests/etc/ssh-disabledalgs.job
@@ -1,0 +1,15 @@
+hostname: localhost
+ssh: True
+ssh_sudo: False
+ssh_username: autorsyncbackup
+ssh_privatekey: /home/autorsyncbackup/.ssh/id_rsa
+ssh_disabledalgs:
+  pubkeys:
+    - rsa-sha2-512
+    - rsa-sha2-256
+backupdir: /tmp
+include: #formerly fileset
+  - /etc
+exclude:
+  - "*.bak"
+  - ".cache/*"

--- a/tests/etc/ssh-no-disabledalgs.job
+++ b/tests/etc/ssh-no-disabledalgs.job
@@ -1,0 +1,5 @@
+hostname: 'localhost'
+ssh: true
+ssh_sudo: true
+ssh_username: 'autorsyncbackup'
+ssh_privatekey: /home/autorsyncbackup/.ssh/id_rsa

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -20,6 +20,7 @@ def test_job():
     assert j.ssh_sudo is False
     assert j.sshusername == 'autorsyncbackup'
     assert j.sshprivatekey == '/home/autorsyncbackup/.ssh/id_rsa'
+    assert j.sshdisabledalgs == {'pubkeys': ['rsa-sha2-512', 'rsa-sha2-256']}
     assert j.rsyncusername == 'autorsyncbackup'
     assert j.rsyncpassword == 'fee-fi-fo-fum'
     assert j.port == 10873
@@ -66,6 +67,7 @@ def test_default_config(test_config):
     assert j.ssh_sudo is False
     assert j.sshusername is None
     assert j.sshprivatekey is None
+    assert j.sshdisabledalgs == {}
     assert j.rsyncusername == 'autorsyncbackup'
     assert j.rsyncpassword == 'fee-fi-fo-fum'
     assert j.rsyncshare == 'backup'
@@ -143,6 +145,23 @@ def test_ssh_no_privatekey():
     assert j.ssh_sudo is True
     assert j.sshusername == 'autorsyncbackup'
     assert j.sshprivatekey is None
+
+
+def test_ssh_no_disabledalgs():
+    path = os.path.join(
+               os.path.dirname(__file__),
+               'etc/ssh-no-disabledalgs.job',
+           )
+
+    j = job(path)
+
+    assert j.enabled is False
+    assert j.hostname == 'localhost'
+    assert j.ssh is True
+    assert j.ssh_sudo is True
+    assert j.sshusername == 'autorsyncbackup'
+    assert j.sshprivatekey == '/home/autorsyncbackup/.ssh/id_rsa'
+    assert j.sshdisabledalgs == {}
 
 
 def test_ssh_no_port():


### PR DESCRIPTION
Running the tests in a Debian bookworm environment revealed some issues.

 * flake8: E275 missing whitespace after keyword.
   Fixed by putting a space between `if` and `(`.
 * flake8: flake8: E501 line too long
   Fixed by using multiple lines for the comment.
 * Test coverage was missing since 005f75ab590849caa47506842622025fdb535433.
    Fixed by restoring the pytest-cov options in `setup.cfg`.
 * Remote hooks fails on Debian squeeze hosts.
   Fixed by adding `sshdisabledalgs` option to jobs which is passed to `paramiko.SSHClient.connect()` as the its `disabled_algorithms` argument.
   See also: https://www.paramiko.org/changelog.html#2.9.0
